### PR TITLE
Fix Reauth Loop on Login Form; Load L10N Files

### DIFF
--- a/shibboleth.php
+++ b/shibboleth.php
@@ -459,6 +459,7 @@ add_filter( 'shibboleth_user_nicename', 'sanitize_user' );
  */
 function shibboleth_login_form() {
 	$login_url = add_query_arg('action', 'shibboleth');
+	$login_url = remove_query_arg('reauth', $login_url);
 	echo '<p id="shibboleth_login"><a href="' . $login_url . '">' . __('Login with Shibboleth', 'shibboleth') . '</a></p>';
 }
 add_action('login_form', 'shibboleth_login_form');
@@ -505,3 +506,10 @@ function shibboleth_delete_option($key) {
 	return function_exists('delete_site_option') ? delete_site_option($key) : delete_option($key);
 }
 
+/**
+ * Load localization files.
+ */
+function shibboleth_load_textdomain() {
+	load_plugin_textdomain('shibboleth', false, dirname( plugin_basename( __FILE__ ) ) . '/localization/');
+}
+add_action('plugins_loaded', 'shibboleth_load_textdomain');


### PR DESCRIPTION
Remove reauth argument to avoid destruction of session immediately after login. Add load_plugin_textdomain() call so that language overrides are used.
