### PR TITLE
added shibboleth_getenv

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Shibboleth ===
-Contributors: willnorris, mitchoyoshitaka
+Contributors: willnorris, mitchoyoshitaka, cjbrabec
 Tags: shibboleth, authentication, login, saml
 Requires at least: 3.3
-Tested up to: 3.9
+Tested up to: 4.2
 Stable tag: 1.6
 
 Allows WordPress to externalize user authentication and account creation to a

--- a/shibboleth.php
+++ b/shibboleth.php
@@ -23,12 +23,18 @@ if ($shibboleth_plugin_revision === false || SHIBBOLETH_PLUGIN_REVISION != $shib
  * REDIRECT_ environment variables automatically.
  */
 function shibboleth_getenv( $var ) {
-    if (getenv($var)) return getenv($var);
-    if (getenv('REDIRECT_'.$var)) return getenv('REDIRECT_'.$var);
-    // httpd can rewrite vars on redirects, this is the most common case
-    $var = preg_replace('/-/','_',$var);
-    if (getenv($var)) return getenv($var);
-    if (getenv('REDIRECT_'.$var)) return getenv('REDIRECT_'.$var);
+    $var_under = str_replace('-', '_', $var);
+    $check_vars = array(
+        $var => TRUE,
+        'REDIRECT_' . $var => TRUE,
+        $var_under => TRUE,
+        'REDIRECT_' . $var_under => TRUE,
+    );
+    foreach ($check_vars as $check_var => $true) {
+        if ( ($result = getenv($check_var)) !== FALSE ) {
+            return $result;
+        }
+    }
     return FALSE;
 }
 
@@ -385,7 +391,7 @@ function shibboleth_get_user_role() {
 
 		if ( empty($role_header) || empty($role_value) ) continue;
 
-		$values = split(';', shibboleth_getenv($role_header));
+		$values = explode(';', shibboleth_getenv($role_header));
 		if ( in_array($role_value, $values) ) {
 			$user_role = $key;
 			break;


### PR DESCRIPTION
We're running various hosting services on our campus using different installations of PHP. Some folks have mod_php with the standard behavior. Others are using Apache + mod_fastcgi + php-fpm. On those servers, the Apache httpd rewrites all the environment variables from Shibboleth by prefixing them with 'REDIRECT_'. So for example,

```
eppn => REDIRECT_eppn
givenName => REDIRECT_givenName
etc.
```

One of our problems is that we'd like to offer the ability to move to newer PHP versions on the same server, which means moving from mod_php to mod_fastcgi and hoping that we don't break Wordpress and this Shibboleth plugin in particular. 

The pull request is to include the code that I added to allow this plugin to handle Shibboleth environment variables the same way, regardless of whether the PHP engine is running as mod_php or mod_fastcgi. I've tested this modification on my Wordpress 4.2.2 test server, using mod_php 5.3.x and mod_fastcgi+php-fpm 5.4.x, 5.5.x, and 5.6.x. It appears to work correctly and transparently.
