### PR TITLE
added multisite current_blog redirect

### DIFF
--- a/shibboleth.php
+++ b/shibboleth.php
@@ -246,7 +246,10 @@ function shibboleth_session_initiator_url($redirect = null) {
 
 	// first build the target URL.  This is the WordPress URL the user will be returned to after Shibboleth 
 	// is done, and will handle actually logging the user into WordPress using the data provdied by Shibboleth 
-	if ( function_exists('switch_to_blog') ) switch_to_blog($GLOBALS['current_site']->blog_id);
+	if ( function_exists('switch_to_blog') ) {
+		if ( is_multisite() ) switch_to_blog($GLOBALS['current_blog']->blog_id);
+		else switch_to_blog($GLOBALS['current_site']->blog_id);
+	}
 	$target = site_url('wp-login.php');
 	if ( function_exists('restore_current_blog') ) restore_current_blog();
 


### PR DESCRIPTION
When logging in via shibboleth on a multi-site installation, the user is redirected to the main site, whether or not the user initiated the login on one of the sub-sites. This commit adds a conditional such that, if it's a multi-site install, the user will be redirected to whatever site they initiated the login from. If it's not a multi-site, the usual redirect will occur.
