### PR TITLE
Update some WordPress API calls and some PHP 7 support

### DIFF
--- a/options-user.php
+++ b/options-user.php
@@ -13,7 +13,7 @@ add_action('admin_footer-user-edit.php', 'shibboleth_admin_footer_edit_user');
  */
 function shibboleth_profile_personal_options() {
 	$user = wp_get_current_user();
-	if (get_usermeta($user->ID, 'shibboleth_account')) {
+	if (get_user_meta($user->ID, 'shibboleth_account')) {
 		add_filter('show_password_fields', create_function('$v', 'return false;'));
 
 		add_action('admin_footer-profile.php', 'shibboleth_admin_footer_profile');
@@ -48,7 +48,7 @@ function shibboleth_admin_footer_profile() {
 function shibboleth_admin_footer_edit_user() {
 	global $user_id;
 
-	if (get_usermeta($user_id, 'shibboleth_account')) {
+	if (get_user_meta($user_id, 'shibboleth_account')) {
 		$shibboleth_fields = array();
 
 		$shibboleth_fields = array_merge($shibboleth_fields, shibboleth_get_managed_user_fields());
@@ -84,7 +84,7 @@ function shibboleth_admin_footer_edit_user() {
 function shibboleth_show_user_profile() {
 	$user = wp_get_current_user();
 	$password_change_url = shibboleth_get_option('shibboleth_password_change_url');
-	if (get_usermeta($user->ID, 'shibboleth_account') && !empty($password_change_url) ) {
+	if (get_user_meta($user->ID, 'shibboleth_account') && !empty($password_change_url) ) {
 ?>
 	<table class="form-table">
 		<tr>
@@ -105,7 +105,7 @@ function shibboleth_show_user_profile() {
 function shibboleth_personal_options_update() {
 	$user = wp_get_current_user();
 
-	if ( get_usermeta($user->ID, 'shibboleth_account') ) {
+	if ( get_user_meta($user->ID, 'shibboleth_account') ) {
 		$managed = shibboleth_get_managed_user_fields();
 
 		if ( in_array('first_name', $managed) ) {

--- a/shibboleth.php
+++ b/shibboleth.php
@@ -171,7 +171,11 @@ function shibboleth_authenticate($user, $username, $password) {
 	if ( shibboleth_session_active() ) {
 		return shibboleth_authenticate_user();
 	} else {
-		$initiator_url = shibboleth_session_initiator_url( $_REQUEST['redirect_to'] );
+		if (isset( $_REQUEST['redirect_to'] )) {
+			$initiator_url = shibboleth_session_initiator_url( $_REQUEST['redirect_to'] );
+		} else {
+			$initiator_url = shibboleth_session_initiator_url();
+		}
 		wp_redirect($initiator_url);
 		exit;
 	}
@@ -197,7 +201,7 @@ function shibboleth_retrieve_password( $user_login ) {
 
 	if ( !empty($password_reset_url) ) {
 		$user = get_userdatabylogin($user_login);
-		if ( $user && get_usermeta($user->ID, 'shibboleth_account') ) {
+		if ( $user && get_user_meta($user->ID, 'shibboleth_account') ) {
 			wp_redirect($password_reset_url);
 			exit;
 		}
@@ -246,7 +250,11 @@ function shibboleth_session_initiator_url($redirect = null) {
 
 	// first build the target URL.  This is the WordPress URL the user will be returned to after Shibboleth 
 	// is done, and will handle actually logging the user into WordPress using the data provdied by Shibboleth 
-	if ( function_exists('switch_to_blog') ) switch_to_blog($GLOBALS['current_site']->blog_id);
+	if ( function_exists('switch_to_blog') ) {
+		if ( is_multisite() ) switch_to_blog($GLOBALS['current_blog']->blog_id);
+		else switch_to_blog($GLOBALS['current_site']->blog_id);
+	}
+
 	$target = site_url('wp-login.php');
 	if ( function_exists('restore_current_blog') ) restore_current_blog();
 
@@ -290,21 +298,22 @@ function shibboleth_authenticate_user() {
 	}
 
 	$username = $_SERVER[$shib_headers['username']['name']];
-	$user = new WP_User($username);
+	//$user = new WP_User($username);
+	$user = get_user_by('login', $username);
 
-	if ( $user->ID ) {
-		if ( !get_usermeta($user->ID, 'shibboleth_account') ) {
+	if ( $user ) {
+		if ( !get_user_meta($user->ID, 'shibboleth_account') ) {
 			// TODO: what happens if non-shibboleth account by this name already exists?
 			//return new WP_Error('invalid_username', __('Account already exists by this name.'));
 		}
 	}
 
 	// create account if new user
-	if ( !$user->ID ) {
+	if ( !$user ) {
 		$user = shibboleth_create_new_user($username);
 	}
 
-	if ( !$user->ID ) {
+	if ( !$user ) {
 		$error_message = 'Unable to create account based on data provided.';
 		if (defined('WP_DEBUG') && WP_DEBUG) {
 			$error_message .= '<!-- ' . print_r($_SERVER, true) . ' -->';
@@ -313,7 +322,7 @@ function shibboleth_authenticate_user() {
 	}
 
 	// update user data
-	update_usermeta($user->ID, 'shibboleth_account', true);
+	update_user_meta($user->ID, 'shibboleth_account', true);
 	shibboleth_update_user_data($user->ID);
 	if ( shibboleth_get_option('shibboleth_update_roles') ) {
 		$user->set_role($user_role);
@@ -334,10 +343,9 @@ function shibboleth_create_new_user($user_login) {
 	if ( empty($user_login) ) return null;
 
 	// create account and flag as a shibboleth acount
-	require_once( ABSPATH . WPINC . '/registration.php' );
-	$user_id = wp_insert_user(array('user_login'=>$user_login));
+	$user_id = wp_insert_user(array('user_login'=>$user_login, 'user_pass' => NULL));
 	$user = new WP_User($user_id);
-	update_usermeta($user->ID, 'shibboleth_account', true);
+	update_user_meta($user->ID, 'shibboleth_account', true);
 
 	// always update user data and role on account creation
 	shibboleth_update_user_data($user->ID, true);
@@ -371,7 +379,7 @@ function shibboleth_get_user_role() {
 
 		if ( empty($role_header) || empty($role_value) ) continue;
 
-		$values = split(';', $_SERVER[$role_header]);
+		$values = explode(';', $_SERVER[$role_header]);
 		if ( in_array($role_value, $values) ) {
 			$user_role = $key;
 			break;
@@ -394,8 +402,10 @@ function shibboleth_get_managed_user_fields() {
 	$managed = array();
 
 	foreach ($headers as $name => $value) {
-		if ( $value['managed'] ) {
-			$managed[] = $name;
+		if (isset($value['managed'])) {
+			if ( $value['managed'] ) {
+				$managed[] = $name;
+			}
 		}
 	}
 
@@ -415,7 +425,6 @@ function shibboleth_get_managed_user_fields() {
  *       nickname, display_name, email
  */
 function shibboleth_update_user_data($user_id, $force_update = false) {
-	require_once( ABSPATH . WPINC . '/registration.php' );
 
 	$shib_headers = shibboleth_get_option('shibboleth_headers');
 
@@ -434,7 +443,11 @@ function shibboleth_update_user_data($user_id, $force_update = false) {
 	);
 	
 	foreach ($user_fields as $field => $header) {
-		if ( $force_update || $shib_headers[$header]['managed'] ) {
+		$managed = false;
+		if (isset($shib_headers[$header]['managed'])) {
+			$managed = $shib_headers[$header]['managed'];
+		}
+		if ( $force_update || $managed ) {
 			$filter = 'shibboleth_' . ( strpos($field, 'user_') === 0 ? '' : 'user_' ) . $field;
 			$user_data[$field] = apply_filters($filter, $_SERVER[$shib_headers[$header]['name']]);
 		}


### PR DESCRIPTION
Added multi-site support for switch to blog functionality
and updated calls to use the newer WordPress user object.

Replace deprecated get_usermetadata call with get_user_meta.

Check for index 'redirect_to' for $_REQUEST before calling
shibboleth_session_initiator_url to avoid PHP notice.

Updated deprecated call update_usermeta to update_user_metada.

Replaced a call to the split() function with explode() since
split is deprecated in PHP 5.3 and is no longer available
in PHP 7.
