### PR TITLE
Add 'shibboleth_authenticate_user' filter.

### DIFF
--- a/shibboleth.php
+++ b/shibboleth.php
@@ -292,14 +292,18 @@ function shibboleth_authenticate_user() {
 	$username = $_SERVER[$shib_headers['username']['name']];
 
 	/**
-	 * Filters whether the given Shibboleth user should be authenticated by WP.
+	 * Allows a bypass mechanism for native Shibboleth authentication.
 	 *
-	 * Return false to prevent the authentication of an existing user or the
-	 * provisioning of a new user.
+	 * Returning a non-null value from this filter will result in your value being
+	 * returned to WordPress. You can prevent a user from being authenticated
+	 * by returning a WP_Error object.
+	 *
+	 * @param null   $auth
+	 * @param string $username
 	 */
-	$authenticate = apply_filters( 'shibboleth_authenticate_user', true, $username );
-	if ( false === $authenticate ) {
-		return null;
+	$authenticate = apply_filters( 'shibboleth_authenticate_user', null, $username );
+	if ( null !== $authenticate ) {
+		return $authenticate;
 	}
 
 	$user = new WP_User($username);

--- a/shibboleth.php
+++ b/shibboleth.php
@@ -290,6 +290,18 @@ function shibboleth_authenticate_user() {
 	}
 
 	$username = $_SERVER[$shib_headers['username']['name']];
+
+	/**
+	 * Filters whether the given Shibboleth user should be authenticated by WP.
+	 *
+	 * Return false to prevent the authentication of an existing user or the
+	 * provisioning of a new user.
+	 */
+	$authenticate = apply_filters( 'shibboleth_authenticate_user', true, $username );
+	if ( false === $authenticate ) {
+		return null;
+	}
+
 	$user = new WP_User($username);
 
 	if ( $user->ID ) {


### PR DESCRIPTION
Hi @mitcho!

I have a use case where I'd like to reject or allow authentication (for new or existing users) based on a custom header sent by the Shibboleth Apache module. There's no natural place in the plugin to intervene in the auth process, so I've introduced a new filter. My callback will look like this:

```
add_filter( 'shibboleth_authenticate_user', function( $auth, $username ) {
    if ( $username doesn't meet my criteria ) {
        $auth = false;
    }
    return $auth;
} );
```

Thanks for considering!
