### PR TITLE
Fix another 'undefined index' notice and html typo

### DIFF
--- a/options-admin.php
+++ b/options-admin.php
@@ -226,35 +226,35 @@ function shibboleth_options_page() {
 					<td><input type="text" id="first_name" name="headers[first_name][name]" value="<?php echo
 						$shib_headers['first_name']['name'] ?>" /></td>
 					<td><input type="checkbox" id="first_name_managed" name="headers[first_name][managed]" <?php
-						checked($shib_headers['first_name']['managed'], 'on') ?> /> <?php _e('Managed', 'shibboleth') ?></td>
+						if (isset($shib_headers['first_name']['managed'])) checked($shib_headers['first_name']['managed'], 'on') ?> /> <?php _e('Managed', 'shibboleth') ?></td>
 				</tr>
 				<tr valign="top">
 					<th scope="row"><label for="last_name"><?php _e('Last name') ?></label></th>
 					<td><input type="text" id="last_name" name="headers[last_name][name]" value="<?php echo
 						$shib_headers['last_name']['name'] ?>" /></td>
 					<td><input type="checkbox" id="last_name_managed" name="headers[last_name][managed]" <?php
-						checked($shib_headers['last_name']['managed'], 'on') ?> /> <?php _e('Managed', 'shibboleth') ?></td>
+						if (isset($shib_headers['last_name']['managed'])) checked($shib_headers['last_name']['managed'], 'on') ?> /> <?php _e('Managed', 'shibboleth') ?></td>
 				</tr>
 				<tr valign="top">
 					<th scope="row"><label for="nickname"><?php _e('Nickname') ?></label></th>
 					<td><input type="text" id="nickname" name="headers[nickname][name]" value="<?php echo
 						$shib_headers['nickname']['name'] ?>" /></td>
 					<td><input type="checkbox" id="nickname_managed" name="headers[nickname][managed]" <?php
-						checked($shib_headers['nickname']['managed'], 'on') ?> /> <?php _e('Managed', 'shibboleth') ?></td>
+						if (isset($shib_headers['nickname']['managed'])) checked($shib_headers['nickname']['managed'], 'on') ?> /> <?php _e('Managed', 'shibboleth') ?></td>
 				</tr>
 				<tr valign="top">
 					<th scope="row"><label for="_display_name"><?php _e('Display name', 'shibboleth') ?></label></th>
 					<td><input type="text" id="_display_name" name="headers[display_name][name]" value="<?php echo
 						$shib_headers['display_name']['name'] ?>" /></td>
 					<td><input type="checkbox" id="display_name_managed" name="headers[display_name][managed]" <?php
-						checked($shib_headers['display_name']['managed'], 'on') ?> /> <?php _e('Managed', 'shibboleth') ?></td>
+						if (isset($shib_headers['display_name']['managed'])) checked($shib_headers['display_name']['managed'], 'on') ?> /> <?php _e('Managed', 'shibboleth') ?></td>
 				</tr>
 				<tr valign="top">
 					<th scope="row"><label for="email"><?php _e('Email Address', 'shibboleth') ?></label></th>
 					<td><input type="text" id="email" name="headers[email][name]" value="<?php echo
 						$shib_headers['email']['name'] ?>" /></td>
 					<td><input type="checkbox" id="email_managed" name="headers[email][managed]" <?php
-						checked($shib_headers['email']['managed'], 'on') ?> /> <?php _e('Managed', 'shibboleth') ?></td>
+						if (isset($shib_headers['email']['managed'])) checked($shib_headers['email']['managed'], 'on') ?> /> <?php _e('Managed', 'shibboleth') ?></td>
 				</tr>
 			</table>
 

--- a/options-admin.php
+++ b/options-admin.php
@@ -127,7 +127,7 @@ function shibboleth_options_page() {
 
 			<table class="form-table">
 				<tr valign="top">
-					<th scope="row"><label for="login_url"><?php _e('Session Initiator URL', 'shibboleth') ?></label</th>
+					<th scope="row"><label for="login_url"><?php _e('Session Initiator URL', 'shibboleth') ?></label></th>
 					<td>
 						<input type="text" id="login_url" name="login_url" value="<?php echo shibboleth_get_option('shibboleth_login_url') ?>" size="50" /><br />
 						<?php _e('This URL is constructed from values found in your main Shibboleth'
@@ -139,7 +139,7 @@ function shibboleth_options_page() {
 					</td>
 				</tr>
 				<tr valign="top">
-					<th scope="row"><label for="logout_url"><?php _e('Logout URL', 'shibboleth') ?></label</th>
+					<th scope="row"><label for="logout_url"><?php _e('Logout URL', 'shibboleth') ?></label></th>
 					<td>
 						<input type="text" id="logout_url" name="logout_url" value="<?php echo shibboleth_get_option('shibboleth_logout_url') ?>" size="50" /><br />
 						<?php _e('This URL is constructed from values found in your main Shibboleth'
@@ -152,14 +152,14 @@ function shibboleth_options_page() {
 					</td>
 				</tr>
 				<tr valign="top">
-					<th scope="row"><label for="password_change_url"><?php _e('Password Change URL', 'shibboleth') ?></label</th>
+					<th scope="row"><label for="password_change_url"><?php _e('Password Change URL', 'shibboleth') ?></label></th>
 					<td>
 						<input type="text" id="password_change_url" name="password_change_url" value="<?php echo shibboleth_get_option('shibboleth_password_change_url') ?>" size="50" /><br />
 						<?php _e('If this option is set, Shibboleth users will see a "change password" link on their profile page directing them to this URL.', 'shibboleth') ?>
 					</td>
 				</tr>
 				<tr valign="top">
-					<th scope="row"><label for="password_reset_url"><?php _e('Password Reset URL', 'shibboleth') ?></label</th>
+					<th scope="row"><label for="password_reset_url"><?php _e('Password Reset URL', 'shibboleth') ?></label></th>
 					<td>
 						<input type="text" id="password_reset_url" name="password_reset_url" value="<?php echo shibboleth_get_option('shibboleth_password_reset_url') ?>" size="50" /><br />
 						<?php _e('If this option is set, Shibboleth users who try to reset their forgotten password using WordPress will be redirected to this URL.', 'shibboleth') ?>
@@ -216,41 +216,41 @@ function shibboleth_options_page() {
 
 			<table class="form-table optiontable editform" cellspacing="2" cellpadding="5">
 				<tr valign="top">
-					<th scope="row"><label for="username"><?php _e('Username') ?></label</th>
+					<th scope="row"><label for="username"><?php _e('Username') ?></label></th>
 					<td><input type="text" id="username" name="headers[username][name]" value="<?php echo
 						$shib_headers['username']['name'] ?>" /></td>
 					<td width="60%"></td>
 				</tr>
 				<tr valign="top">
-					<th scope="row"><label for="first_name"><?php _e('First name') ?></label</th>
+					<th scope="row"><label for="first_name"><?php _e('First name') ?></label></th>
 					<td><input type="text" id="first_name" name="headers[first_name][name]" value="<?php echo
 						$shib_headers['first_name']['name'] ?>" /></td>
 					<td><input type="checkbox" id="first_name_managed" name="headers[first_name][managed]" <?php
 						checked($shib_headers['first_name']['managed'], 'on') ?> /> <?php _e('Managed', 'shibboleth') ?></td>
 				</tr>
 				<tr valign="top">
-					<th scope="row"><label for="last_name"><?php _e('Last name') ?></label</th>
+					<th scope="row"><label for="last_name"><?php _e('Last name') ?></label></th>
 					<td><input type="text" id="last_name" name="headers[last_name][name]" value="<?php echo
 						$shib_headers['last_name']['name'] ?>" /></td>
 					<td><input type="checkbox" id="last_name_managed" name="headers[last_name][managed]" <?php
 						checked($shib_headers['last_name']['managed'], 'on') ?> /> <?php _e('Managed', 'shibboleth') ?></td>
 				</tr>
 				<tr valign="top">
-					<th scope="row"><label for="nickname"><?php _e('Nickname') ?></label</th>
+					<th scope="row"><label for="nickname"><?php _e('Nickname') ?></label></th>
 					<td><input type="text" id="nickname" name="headers[nickname][name]" value="<?php echo
 						$shib_headers['nickname']['name'] ?>" /></td>
 					<td><input type="checkbox" id="nickname_managed" name="headers[nickname][managed]" <?php
 						checked($shib_headers['nickname']['managed'], 'on') ?> /> <?php _e('Managed', 'shibboleth') ?></td>
 				</tr>
 				<tr valign="top">
-					<th scope="row"><label for="_display_name"><?php _e('Display name', 'shibboleth') ?></label</th>
+					<th scope="row"><label for="_display_name"><?php _e('Display name', 'shibboleth') ?></label></th>
 					<td><input type="text" id="_display_name" name="headers[display_name][name]" value="<?php echo
 						$shib_headers['display_name']['name'] ?>" /></td>
 					<td><input type="checkbox" id="display_name_managed" name="headers[display_name][managed]" <?php
 						checked($shib_headers['display_name']['managed'], 'on') ?> /> <?php _e('Managed', 'shibboleth') ?></td>
 				</tr>
 				<tr valign="top">
-					<th scope="row"><label for="email"><?php _e('Email Address', 'shibboleth') ?></label</th>
+					<th scope="row"><label for="email"><?php _e('Email Address', 'shibboleth') ?></label></th>
 					<td><input type="text" id="email" name="headers[email][name]" value="<?php echo
 						$shib_headers['email']['name'] ?>" /></td>
 					<td><input type="checkbox" id="email_managed" name="headers[email][managed]" <?php


### PR DESCRIPTION
The first commit fixes html typo `</label` to `</label>` in options-admin.php.
The second one checks whether `$shib_headers[*]['managed']` is set before use their value.